### PR TITLE
Do not require CPU variant of pytorch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -24,7 +24,7 @@ requirements:
     - numpy >=1.16.2
     - pandas
     - python >=3.6
-    - pytorch-cpu >=1.2.0
+    - pytorch >=1.2.0
     - requests >=2.22.0
     - sentencepiece
     - transformers


### PR DESCRIPTION
@thewchan The `nlpaug` package is preventing downstream packages from installing the pytorch GPU version because the nlpaug recipe specifies `pytorch-cpu` in it. The `-cpu` sign should be removed as conda-forge can automatically figure out whether users' computer has GPU or not and install the preferred pytorch version properly. 

@h-vetinari @Innixma

Relevant issues:
- https://github.com/autogluon/autogluon/issues/612#issuecomment-1407273592
- https://github.com/conda-forge/pytorch-cpu-feedstock/issues/155


![image](https://user-images.githubusercontent.com/5016453/215239850-f6b503c8-4548-40fd-bcc1-b419cc9beca3.png)

![image](https://user-images.githubusercontent.com/5016453/215239864-58775eca-ac66-45f6-8793-8fb37b2fe6d5.png)

![image](https://user-images.githubusercontent.com/5016453/215239910-677beca7-48e0-4abd-984a-cf6175042ecc.png)